### PR TITLE
Reinstate skipped test and remove print statement

### DIFF
--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -11,7 +11,6 @@ import os
 
 def test_ping(nhsd_apim_proxy_url):
     os.environ["PROXY_NAME"] = "dev"
-    # print(env)
     resp = requests.get(f"{nhsd_apim_proxy_url}/_ping")
     assert resp.status_code == 200
 
@@ -37,13 +36,13 @@ def test_wait_for_ping(nhsd_apim_proxy_url):
 
 
 @pytest.mark.smoketest
-@pytest.mark.skip(reason="No longer required 30/10/2023")
-def test_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):
+def test_status_endpoint(nhsd_apim_proxy_url, status_endpoint_auth_headers):
     resp = requests.get(
         f"{nhsd_apim_proxy_url}/_status", headers=status_endpoint_auth_headers
     )
     assert resp.status_code == 200
-    # Make some additional assertions about your status response here!
+    status_json = resp.json()
+    assert status_json["status"] == "pass"
 
 
 def test_wait_for_status(nhsd_apim_proxy_url, status_endpoint_auth_headers):


### PR DESCRIPTION
Reenabled the previously skipped 'test_status' function in the test_endpoints.py file and renamed it to 'test_status_endpoint'. Removed a redundant print statement from the 'test_ping' function. The updated 'test_status_endpoint' now includes additional assertions to verify the response status.

## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

Add any other relevant notes or explanations here. **Remove this line if you have nothing to add.**


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [x] I have ensured the changelog has been updated by the submitter, if necessary.
