### PR TITLE
Correct dependency reference in azure pipeline

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -60,7 +60,7 @@ extends:
                   -   template: ./templates/run-tests.yml
             - environment: int
               depends_on:
-                  - internal-dev
+                  - internal_dev
               post_deploy:
                   - template: ./templates/run-tests.yml
                     parameters:


### PR DESCRIPTION
Fixed an incorrect reference in the Azure DevOps release pipeline configuration file from 'internal-dev' to 'internal_dev'. This change ensures the correct deployment sequence for environments in the pipeline, allowing subsequent steps to execute after the successful completion of 'internal_dev'.

## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

Add any other relevant notes or explanations here. **Remove this line if you have nothing to add.**


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
