### PR TITLE
Add parameters to ApplyRateLimiting flow callout

### DIFF
--- a/proxies/live/apiproxy/policies/FlowCallout.ApplyRateLimiting.xml
+++ b/proxies/live/apiproxy/policies/FlowCallout.ApplyRateLimiting.xml
@@ -3,6 +3,6 @@
     <DisplayName>FlowCallout.ApplyRateLimiting</DisplayName>
     <SharedFlowBundle>ApplyRateLimiting</SharedFlowBundle>
     <Parameters>
-      <Parameter name="verifyApiKeyPolicyName">VerifyApiKey.FromHeader</Parameter>
+      <Parameter name="verifyApiKeyPolicyName">VerifyAPIKey.FromHeader</Parameter>
     </Parameters>
 </FlowCallout>

--- a/proxies/live/apiproxy/policies/FlowCallout.ApplyRateLimiting.xml
+++ b/proxies/live/apiproxy/policies/FlowCallout.ApplyRateLimiting.xml
@@ -2,4 +2,7 @@
 <FlowCallout async="false" continueOnError="false" enabled="true" name="FlowCallout.ApplyRateLimiting">
     <DisplayName>FlowCallout.ApplyRateLimiting</DisplayName>
     <SharedFlowBundle>ApplyRateLimiting</SharedFlowBundle>
+    <Parameters>
+      <Parameter name="verifyApiKeyPolicyName">VerifyApiKey.FromHeader</Parameter>
+    </Parameters>
 </FlowCallout>

--- a/proxies/live/apiproxy/policies/FlowCallout.ApplyRateLimiting.xml
+++ b/proxies/live/apiproxy/policies/FlowCallout.ApplyRateLimiting.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <FlowCallout async="false" continueOnError="false" enabled="true" name="FlowCallout.ApplyRateLimiting">
-    <DisplayName>FlowCallout.ApplyRateLimiting</DisplayName>
+    <DisplayName>Apply Rate Limiting</DisplayName>
     <SharedFlowBundle>ApplyRateLimiting</SharedFlowBundle>
     <Parameters>
       <Parameter name="verifyApiKeyPolicyName">VerifyAPIKey.FromHeader</Parameter>


### PR DESCRIPTION
A 'Parameters' section was added to the 'FlowCallout.ApplyRateLimiting' in apiproxy/policies. This includes a parameter named 'verifyApiKeyPolicyName' with the value 'VerifyApiKey.FromHeader'. This will ensure that the API key is verified from the header, improving the security measure of the process.

## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

Add any other relevant notes or explanations here. **Remove this line if you have nothing to add.**


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
